### PR TITLE
Add publish script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "preview": "svelte-kit preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
-    "package": "svelte-kit package"
+    "package": "svelte-kit package",
+    "publish": "npm publish ./package"
   },
   "devDependencies": {
     "@sveltejs/kit": "next",


### PR DESCRIPTION
Might just be me but I found myself running `npm publish` without `./package` and messing up my package a few times. This PR adds a publish script that publishes the ./package directory. And `npm run publish` is 28.5% shorter than `npm publish ./package` so that's a plus point too.

Of course, it assumes that the user hasn't replaced npm completely with another package manager, but if they have then they could very easily change it when they visit package.json to change the package name.